### PR TITLE
Update Usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Set up a 'print' subcommand:
 
 ```go
 import (
+  "context"
   "flag"
   "fmt"
   "os"
   "strings"
 
   "github.com/google/subcommands"
-  "golang.org/x/net/context"
 )
 
 type printCmd struct {


### PR DESCRIPTION
`golang.org/x/net/context` is no longer used.