### PR TITLE
Adds subcommand suggestions for apparent typos.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,5 @@
 module github.com/google/subcommands
+
+go 1.12
+
+require github.com/agext/levenshtein v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
+github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/subcommands.go
+++ b/subcommands.go
@@ -27,6 +27,8 @@ import (
 	"path"
 	"sort"
 	"strings"
+
+	"github.com/agext/levenshtein"
 )
 
 // A Command represents a single command.
@@ -203,7 +205,33 @@ func (cdr *Commander) Execute(ctx context.Context, args ...interface{}) ExitStat
 
 	// Cannot find this command.
 	cdr.topFlags.Usage()
+
+	if suggestion, found := cdr.suggestion(name); found {
+		fmt.Fprintf(cdr.Output, "\n%q is not a subcommand. Did you mean %q?\n", name, suggestion)
+	}
+
 	return ExitUsageError
+}
+
+// suggestion compares the given subcommand name to all registered commands to
+// check for typos. It returns the suggested alternative command, if any, and a
+// boolean indicating if a suggestion was found.
+func (cdr *Commander) suggestion(given string) (string, bool) {
+	// maxMatchDist is the maximum Levenshtein distance to consider an input a probable typo.
+	const maxMatchDist = 2
+
+	minDist := maxMatchDist + 1
+	suggestion := ""
+	for _, group := range cdr.commands {
+		for _, cmd := range group.commands {
+			name := cmd.Name()
+			if dist := levenshtein.Distance(given, name, nil); dist < minDist {
+				minDist = dist
+				suggestion = name
+			}
+		}
+	}
+	return suggestion, (minDist > 0 && minDist <= maxMatchDist)
 }
 
 // Sorting of a slice of command groups.


### PR DESCRIPTION
This adds a dependency on github.com/agext/levenshtein to compute the edit
distance from the given subcommand to the program's registered subcommand names.

Fixes #24 